### PR TITLE
Fixed example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ var slackClient = new SmartSlack(options);
 // Listen for errors...
 slackClient.on('error',function(error) {
     console.log(error);
-}
+});
 
 // Start the Slack RTM session...
 slackClient.start();


### PR DESCRIPTION
The example code was missing a ")". This caused the example code to throw an error.