### PR TITLE
Accept new bottoken format

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,7 +38,7 @@ function SmartSlack(options) {
     // Updated on July 29, 2019 to accommodate new token format.
     // Reference: https://api.slack.com/docs/oauth
     if (typeof accessToken !== 'string' || !accessToken.match(/^([a-z]{4})-([0-9]{11,12})-([0-9a-zA-Z]{24})$/)
-        && !accessToken.match(/^([a-z]{4})-([0-9]{10,11})-([0-9]{11,12})-([0-9a-zA-Z]{24})$/)) {
+        && !accessToken.match(/^([a-z]{4})-([0-9]{10,12})-([0-9]{11,13})-([0-9a-zA-Z]{24})$/)) {
         throw new Error(errors.invalid_token);
     }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -43,6 +43,13 @@ describe('SmartSlack', function () {
             done();
         });
 
+        it('can be constructed using new token_format', function (done) {
+            const newTokenFormat = 'xoxb-474596707840-9999992899999-YUN0pmojbLtZZzzzzaHrZZLI';
+            var slackClient = new SmartSlack({ token: newTokenFormat });
+            slackClient.should.be.an('object'); 
+            done();
+        });
+
         it('should validate required options arguments', function (done) {
             expect(function () {
                 new SmartSlack(null);


### PR DESCRIPTION
During an app upgrade I've notice that the current token format is no longer valid using the current regex.
In order to fix this it's necessary to adjust it's pattern. 